### PR TITLE
Add simple version of #failure_message_when_negated

### DIFF
--- a/lib/rspec/que/queue_up.rb
+++ b/lib/rspec/que/queue_up.rb
@@ -36,6 +36,11 @@ module RSpec
           "#{new_jobs_with_correct_class.first[:args]}"
         end
 
+        def failure_message_when_negated
+          "expected to not enqueue anything, got %s enqueued with %s" %
+            [new_jobs.first[:job_class], new_jobs.first[:args]]
+        end
+
         def supports_block_expectations?
           true
         end

--- a/lib/rspec/que/version.rb
+++ b/lib/rspec/que/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module Que
-    VERSION = '0.1.0'.freeze
+    VERSION = '0.1.1'.freeze
   end
 end

--- a/spec/rspec/que/queue_up_spec.rb
+++ b/spec/rspec/que/queue_up_spec.rb
@@ -46,6 +46,16 @@ RSpec.describe RSpec::Que::Matchers::QueueUp do
 
       it { is_expected.to be(true) }
     end
+
+    context "and nothing was expected" do
+      let(:proc) { -> { enqueued_jobs << { job_class: "AJob", args: [] } } }
+
+      specify do
+        matches?
+        expect(instance.failure_message_when_negated).
+          to eq("expected to not enqueue anything, got AJob enqueued with []")
+      end
+    end
   end
 
   context "with argument expectations" do


### PR DESCRIPTION
RSpec tries to use #failure_message_when_negated when a `to_not` expectation fails.

@Sinjo or @barisbalic can you take a look?