### PR TITLE
Refactor match pipeline and add .at(time) matcher

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rspec-que (0.1.0)
+    rspec-que (1.0.0)
       rspec-mocks
 
 GEM
@@ -55,3 +55,6 @@ DEPENDENCIES
   rspec-its
   rspec-que!
   rubocop
+
+BUNDLED WITH
+   1.10.6

--- a/README.md
+++ b/README.md
@@ -1,19 +1,25 @@
 # RSpec Que matchers
 
-This gem defines a matcher for checking that Que jobs have been enqueued.  It is a more
- specific, less featured, clone of
- [rspec-activejob](https://github.com/gocardless/rspec-activejob).
+This gem defines a matcher for checking that Que jobs have been enqueued,
+in the style of [rspec-activejob](https://github.com/gocardless/rspec-activejob).
 
-It expects a block or proc to enqueue a job in Que. Optionally takes the job class as its
-argument, and can be modified with a `.with(*args)` call to expect specific arguments.
-This will use the same argument list matcher as rspec-mocks' `receive(:message).with(*args)` matcher.
+## Usage
+The matcher expects a block of code, and will expect that code to enqueue a job
+in Que. The matcher can take a class for the job as its arguments. It can also
+expect the job to be queued with arguments via `.with(arg1, arg2)` or at a
+specific time via `.at(time)`.
+
+If the matcher does not match, it will display informations about jobs queued
+at the last stage of the matcher which did match. (For instance, if you specify
+a job class, arguments, and a time, the matcher will display information about
+jobs of the right class and arguments but at the wrong time.)
 
 ```ruby
 # spec/spec_helper.rb
 require 'rspec/que'
 
 RSpec.configure do |config|
-  config.include(RSpec::ActiveJob)
+  config.include(RSpec::Que)
 
   # clean out the queue after each spec
   config.after(:each) do
@@ -25,10 +31,10 @@ end
 RSpec.describe MyController do
   let(:user) { create(:user) }
   let(:params) { { user_id: user.id } }
+  let(:later_time) { DateTime.parse("2038-01-01T01:02:03+00:00").utc }
   subject(:make_request) { described_class.make_request(params) }
 
   specify { expect { make_request }.to queue_up(RequestMaker).with(user) }
+  specify { expect { make_request }.to queue_up(DelayedRequest).at(later_time) }
 end
 ```
-
-

--- a/lib/rspec/que/queue_up.rb
+++ b/lib/rspec/que/queue_up.rb
@@ -1,9 +1,79 @@
 require 'rspec/mocks/argument_list_matcher'
+require 'time'
 
 module RSpec
   module Que
     module Matchers
       class QueueUp
+        def initialize(job_class = nil)
+          @matchers = [QueuedSomething.new]
+          @matchers << QueuedClass.new(job_class) if job_class
+          @job_class = job_class
+          @stages = []
+        end
+
+        def matches?(block)
+          before_jobs = enqueued_jobs.dup
+          block.call
+
+          @matched_jobs = enqueued_jobs - before_jobs
+          @matchers.each do |matcher|
+            @stages << {matcher: matcher, candidates: @matched_jobs.dup}
+            @matched_jobs.delete_if {|job| !matcher.matches?(job) }
+          end
+          @matched_jobs.any?
+        end
+
+        def with(*args)
+          @matchers << QueuedArgs.new(args)
+          self
+        end
+
+        def at(the_time)
+          matcher = QueuedAt.new(the_time)
+          @matchers << matcher
+          self
+        end
+
+        def failure_message
+          # last stage to have any candidate jobs
+          failed_stage = @stages.reject {|s| s[:candidates].empty? }.last || @stages.first
+          failed_matcher = failed_stage[:matcher]
+          failed_candidates = failed_stage[:candidates]
+          found_instead = failed_matcher.failed_msg(failed_candidates)
+
+          "expected to enqueue #{job_description}, but found #{found_instead}"
+        end
+
+        def failure_message_when_negated
+          "expected not to enqueue #{job_description}, got %d enqueued: %s" %
+            [@matched_jobs.length, @matched_jobs.map { |j| format_job(j) }.join(", ")]
+        end
+
+        def supports_block_expectations?
+          true
+        end
+
+        def description
+          return "queues up a #{job_description}"
+        end
+
+        private
+
+        attr_reader :before_count, :after_count, :job_class, :argument_list_matcher
+
+        def enqueued_jobs
+          ::Que.execute "SELECT * FROM que_jobs"
+        end
+
+        def job_description
+          @matchers.map(&:desc).join(" ")
+        end
+
+        def format_job(job)
+          "#{job[:job_class]}[" + job[:args].join(", ") + "]"
+        end
+
         class QueuedSomething
           def matches?(job)
             true
@@ -59,79 +129,22 @@ module RSpec
         end
 
         class QueuedAt
-          def initiaize(time)
-            @time = time
+          def initialize(the_time)
+            @time = the_time
           end
           def matches?(job)
-            # TODO implement and test
+            job[:run_at] == @time
           end
           def desc
+            "at #{@time}"
           end
-        end
-
-        def initialize(job_class = nil)
-          @matchers = [QueuedSomething.new]
-          @matchers << QueuedClass.new(job_class) if job_class
-          @job_class = job_class
-          @stages = []
-        end
-
-        def matches?(block)
-          before_jobs = enqueued_jobs.dup
-          block.call
-
-          @matched_jobs = enqueued_jobs - before_jobs
-          @matchers.each do |matcher|
-            @stages << {matcher: matcher, candidates: @matched_jobs.dup}
-            @matched_jobs.delete_if {|job| !matcher.matches?(job) }
+          def failed_msg(candidates)
+            if candidates.length == 1
+              "job at #{candidates.first[:run_at].to_s}"
+            else
+              "jobs at #{candidates.map {|c| c[:run_at]}}"
+            end
           end
-          @matched_jobs.any?
-        end
-
-        def with(*args)
-          raise "Must specify the job class when specifying arguments" unless job_class
-          @matchers << QueuedArgs.new(args)
-          self
-        end
-
-
-        def failure_message
-          # last stage to have any candidate jobs
-          failed_stage = @stages.reject {|s| s[:candidates].empty? }.last || @stages.first
-          failed_matcher = failed_stage[:matcher]
-          failed_candidates = failed_stage[:candidates]
-          found_instead = failed_matcher.failed_msg(failed_candidates)
-
-          "expected to enqueue #{job_description}, but found #{found_instead}"
-        end
-
-        def failure_message_when_negated
-          "expected not to enqueue #{job_description}, got %d enqueued: %s" %
-            [@matched_jobs.length, @matched_jobs.map { |j| format_job(j) }.join(", ")]
-        end
-
-        def supports_block_expectations?
-          true
-        end
-
-        def description
-          return "queues up a #{job_description}"
-        end
-
-        private
-
-        attr_reader :before_count, :after_count, :job_class, :argument_list_matcher
-
-        def enqueued_jobs
-          ::Que.execute "SELECT * FROM que_jobs"
-        end
-
-        def job_description
-          @matchers.map(&:desc).join(" ")
-        end
-
-        def format_job(job)
-          "#{job[:job_class]}[" + job[:args].join(", ") + "]"
         end
       end
     end

--- a/lib/rspec/que/queue_up.rb
+++ b/lib/rspec/que/queue_up.rb
@@ -9,7 +9,7 @@ module RSpec
             true
           end
           def desc
-            "to enqueue a job"
+            "a job"
           end
           def failed_msg(last_found)
             "nothing"
@@ -32,8 +32,7 @@ module RSpec
             if classes.length == 1
               classes.first
             else
-              # TODO test me
-              "#{classes.length} job(s) of class #{classes}"
+              "#{classes.length} jobs of class [#{classes.join(', ')}]"
             end
           end
         end
@@ -53,10 +52,8 @@ module RSpec
             if candidates.length == 1
               "job enqueued with #{candidates.first[:args]}"
             else
-              # TODO test
-              "#{candidates.length} jobs with args: " + [
-                candidates.map {|j| j[:args] }
-              ].to_s
+              "#{candidates.length} jobs with args: " +
+                candidates.map {|j| j[:args] }.to_s
             end
           end
         end
@@ -105,13 +102,12 @@ module RSpec
           failed_candidates = failed_stage[:candidates]
           found_instead = failed_matcher.failed_msg(failed_candidates)
 
-          "expected #{job_description}, but found #{found_instead}"
+          "expected to enqueue #{job_description}, but found #{found_instead}"
         end
 
         def failure_message_when_negated
-          matched = @matched_jobs.first
-          "expected not #{job_description}, got %s enqueued with %s" %
-            [matched[:job_class], matched[:args]]
+          "expected not to enqueue #{job_description}, got %d enqueued: %s" %
+            [@matched_jobs.length, @matched_jobs.map { |j| format_job(j) }.join(", ")]
         end
 
         def supports_block_expectations?
@@ -132,6 +128,10 @@ module RSpec
 
         def job_description
           @matchers.map(&:desc).join(" ")
+        end
+
+        def format_job(job)
+          "#{job[:job_class]}[" + job[:args].join(", ") + "]"
         end
       end
     end

--- a/lib/rspec/que/version.rb
+++ b/lib/rspec/que/version.rb
@@ -1,5 +1,5 @@
 module RSpec
   module Que
-    VERSION = '0.1.1'.freeze
+    VERSION = '1.0.0'.freeze
   end
 end

--- a/spec/rspec/que/queue_up_spec.rb
+++ b/spec/rspec/que/queue_up_spec.rb
@@ -117,4 +117,48 @@ RSpec.describe RSpec::Que::Matchers::QueueUp do
       end
     end
   end
+
+  context "with jobs queued at a specific time" do
+    let(:t1) { Time.parse("1997-10-03 01:23:45").utc }
+    let(:t2) { Time.parse("2000-03-21 06:07:08").utc }
+    let(:t3) { Time.parse("1991-07-07 13:57:11").utc }
+    let(:proc) do -> {
+        enqueued_jobs << { job_class: "AJob", args: ['madoka'], run_at: t1 }
+        enqueued_jobs << { job_class: "AJob", args: ['yuna'], run_at: t2 }
+        enqueued_jobs << { job_class: "BJob", args: ['senjougahara'], run_at: t3 }
+      }
+    end
+
+    describe '#at' do
+      it 'should match a job present at the specified time' do
+        expect(instance.at(t2).matches?(proc)).to eq(true)
+        expect(instance.failure_message_when_negated).
+          to eq("expected not to enqueue a job at 2000-03-21 06:07:08 UTC, got 1 enqueued: AJob[yuna]")
+      end
+      it 'should not match if no jobs are present' do
+        expect(instance.at(Time.now).matches?(proc)).to eq(false)
+      end
+      describe 'chaining with previous specifiers' do
+        it 'can chain with args' do
+          expect(instance.with('yuna').at(t3).matches?(proc)).to eq(false)
+          expect(instance.failure_message).
+            to eq(%(expected to enqueue a job with args ["yuna"] at #{t3}, but found job at #{t2}))
+        end
+        describe 'chaining with a class' do
+          let(:job_class) { AJob }
+          it "matches within the class" do
+            expect(instance.at(t3).matches?(proc)).to eq(false)
+            expect(instance.failure_message).
+              to eq(%(expected to enqueue a job of class AJob at #{t3}, but found jobs at [#{t1}, #{t2}]))
+          end
+
+        end
+        it 'can negative-chain' do
+          expect(instance.with('yuna').at(t2).matches?(proc)).to eq(true)
+          expect(instance.failure_message_when_negated).
+            to eq(%(expected not to enqueue a job with args ["yuna"] at #{t2}, got 1 enqueued: AJob[yuna]))
+        end
+      end
+    end
+  end
 end

--- a/spec/rspec/que/queue_up_spec.rb
+++ b/spec/rspec/que/queue_up_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RSpec::Que::Matchers::QueueUp do
     specify do
       matches?
       expect(instance.failure_message).
-        to eq("expected to enqueue a job, enqueued nothing")
+        to eq("expected to enqueue a job, but found nothing")
     end
   end
 
@@ -35,7 +35,7 @@ RSpec.describe RSpec::Que::Matchers::QueueUp do
       specify do
         matches?
         expect(instance.failure_message).
-          to eq("expected to queue up a BJob, enqueued a AJob")
+          to eq("expected to enqueue a job of class BJob, but found AJob")
       end
     end
 
@@ -53,7 +53,7 @@ RSpec.describe RSpec::Que::Matchers::QueueUp do
       specify do
         matches?
         expect(instance.failure_message_when_negated).
-          to eq("expected to not enqueue anything, got AJob enqueued with []")
+          to eq("expected not to enqueue a job, got AJob enqueued with []")
       end
     end
   end
@@ -74,7 +74,7 @@ RSpec.describe RSpec::Que::Matchers::QueueUp do
       specify do
         matches?
         expect(instance.failure_message).
-          to eq("expected to queue up a AJob with #{arguments}, but enqueued with []")
+          to eq("expected to enqueue a job of class AJob with args #{arguments}, but found job enqueued with []")
       end
     end
   end


### PR DESCRIPTION
I needed to make `queue_up(job).at(time)` a thing. I dramatically refactored the matching pipeline so that making `.at` work could be done elegantly.