### PR TITLE
Extend the matcher to support expectations on the number of jobs

### DIFF
--- a/lib/rspec/que/queue_up.rb
+++ b/lib/rspec/que/queue_up.rb
@@ -2,6 +2,13 @@ require 'rspec/mocks/argument_list_matcher'
 require 'time'
 require 'forwardable'
 
+require_relative 'queue_up/queued_something'
+require_relative 'queue_up/queued_priority'
+require_relative 'queue_up/queued_class'
+require_relative 'queue_up/queued_args'
+require_relative 'queue_up/queued_at'
+require_relative 'queue_up/queue_count'
+
 module RSpec
   module Que
     module Matchers
@@ -98,178 +105,6 @@ module RSpec
 
         def format_job(job)
           "#{job[:job_class]}[" + job[:args].join(", ") + "]"
-        end
-
-        class QueuedSomething
-          def matches?(_job)
-            true
-          end
-
-          def desc
-            "a job"
-          end
-
-          def failed_msg(_last_found)
-            "nothing"
-          end
-        end
-
-        class QueuedClass
-          attr_reader :job_class
-          def initialize(job_class)
-            @job_class = job_class
-          end
-
-          def matches?(job)
-            job[:job_class] == job_class.to_s
-          end
-
-          def desc
-            "of class #{job_class}"
-          end
-
-          def failed_msg(candidates)
-            classes = candidates.map { |c| c[:job_class] }
-            if classes.length == 1
-              classes.first
-            else
-              "#{classes.length} jobs of class [#{classes.join(', ')}]"
-            end
-          end
-        end
-
-        class QueuedArgs
-          def initialize(args)
-            @args = args
-            @argument_list_matcher = RSpec::Mocks::ArgumentListMatcher.new(*args)
-          end
-
-          def matches?(job)
-            @argument_list_matcher.args_match?(*job[:args])
-          end
-
-          def desc
-            "with args #{@args}"
-          end
-
-          def failed_msg(candidates)
-            if candidates.length == 1
-              "job enqueued with #{candidates.first[:args]}"
-            else
-              "#{candidates.length} jobs with args: " +
-                candidates.map { |j| j[:args] }.to_s
-            end
-          end
-        end
-
-        class QueuedAt
-          def initialize(the_time)
-            @time = the_time
-          end
-
-          def matches?(job)
-            job[:run_at] == @time
-          end
-
-          def desc
-            "at #{@time}"
-          end
-
-          def failed_msg(candidates)
-            if candidates.length == 1
-              "job at #{candidates.first[:run_at]}"
-            else
-              "jobs at #{candidates.map { |c| c[:run_at] }}"
-            end
-          end
-        end
-
-        class QueuedPriority
-          def initialize(priority)
-            @priority = priority
-          end
-
-          def matches?(job)
-            job[:priority] == @priority
-          end
-
-          def desc
-            "of priority #{@priority}"
-          end
-
-          def failed_msg(candidates)
-            if candidates.length == 1
-              "job of priority #{candidates.first[:priority]}"
-            else
-              "jobs of priority #{candidates.map { |c| c[:priority] }}"
-            end
-          end
-        end
-      end
-
-      class QueueCount
-        EXACTLY = :==
-        AT_LEAST = :>=
-        AT_MOST = :<=
-
-        def initialize(parent_matcher, comparator, number)
-          @number = number
-          @comparator = comparator
-          @parent = parent_matcher
-        end
-
-        def once
-          exactly(1)
-          @parent
-        end
-
-        def twice
-          exactly(2)
-          @parent
-        end
-
-        def exactly(n)
-          set(EXACTLY, n)
-        end
-
-        def at_least(n)
-          set(AT_LEAST, n)
-        end
-
-        def at_most(n)
-          set(AT_MOST, n)
-        end
-
-        def times
-          @parent
-        end
-
-        def matches?(actual_number)
-          actual_number.send(@comparator, @number)
-        end
-
-        def desc
-          case @comparator
-          when EXACTLY then "exactly #{@number} times"
-          when AT_LEAST then "at least #{@number} times"
-          when AT_MOST then "at most #{@number} times"
-          end
-        end
-
-        def failed_msg(candidates)
-          "#{candidates.length} jobs"
-        end
-
-        def default?
-          @comparator == EXACTLY && @number == 1
-        end
-
-        private
-
-        def set(comparator, number)
-          @comparator = comparator
-          @number = number
-          self
         end
       end
     end

--- a/lib/rspec/que/queue_up.rb
+++ b/lib/rspec/que/queue_up.rb
@@ -12,7 +12,7 @@ module RSpec
         def initialize(job_class = nil)
           @matchers = [QueuedSomething.new]
           @matchers << QueuedClass.new(job_class) if job_class
-          @count_matcher = QueueCount.new(self, QueueCount::AT_LEAST, 1)
+          @count_matcher = QueueCount.new(self, QueueCount::EXACTLY, 1)
           @job_class = job_class
           @stages = []
         end
@@ -261,7 +261,7 @@ module RSpec
         end
 
         def default?
-          @comparator == AT_LEAST && @number == 1
+          @comparator == EXACTLY && @number == 1
         end
 
         private

--- a/lib/rspec/que/queue_up/queue_count.rb
+++ b/lib/rspec/que/queue_up/queue_count.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+module RSpec
+  module Que
+    module Matchers
+      class QueueUp
+        class QueueCount
+          EXACTLY = :==
+          AT_LEAST = :>=
+          AT_MOST = :<=
+
+          def initialize(parent_matcher, comparator, number)
+            @number = number
+            @comparator = comparator
+            @parent = parent_matcher
+          end
+
+          def once
+            exactly(1)
+            @parent
+          end
+
+          def twice
+            exactly(2)
+            @parent
+          end
+
+          def exactly(n)
+            set(EXACTLY, n)
+          end
+
+          def at_least(n)
+            set(AT_LEAST, n)
+          end
+
+          def at_most(n)
+            set(AT_MOST, n)
+          end
+
+          def times
+            @parent
+          end
+
+          def matches?(actual_number)
+            actual_number.send(@comparator, @number)
+          end
+
+          def desc
+            case @comparator
+            when EXACTLY then "exactly #{@number} times"
+            when AT_LEAST then "at least #{@number} times"
+            when AT_MOST then "at most #{@number} times"
+            end
+          end
+
+          def failed_msg(candidates)
+            "#{candidates.length} jobs"
+          end
+
+          def default?
+            @comparator == EXACTLY && @number == 1
+          end
+
+          private
+
+          def set(comparator, number)
+            @comparator = comparator
+            @number = number
+            self
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/que/queue_up/queued_args.rb
+++ b/lib/rspec/que/queue_up/queued_args.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module RSpec
+  module Que
+    module Matchers
+      class QueueUp
+        class QueuedArgs
+          def initialize(args)
+            @args = args
+            @argument_list_matcher = RSpec::Mocks::ArgumentListMatcher.new(*args)
+          end
+
+          def matches?(job)
+            @argument_list_matcher.args_match?(*job[:args])
+          end
+
+          def desc
+            "with args #{@args}"
+          end
+
+          def failed_msg(candidates)
+            if candidates.length == 1
+              "job enqueued with #{candidates.first[:args]}"
+            else
+              "#{candidates.length} jobs with args: " +
+                candidates.map { |j| j[:args] }.to_s
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/que/queue_up/queued_at.rb
+++ b/lib/rspec/que/queue_up/queued_at.rb
@@ -1,0 +1,29 @@
+module RSpec
+  module Que
+    module Matchers
+      class QueueUp
+        class QueuedAt
+          def initialize(the_time)
+            @time = the_time
+          end
+
+          def matches?(job)
+            job[:run_at] == @time
+          end
+
+          def desc
+            "at #{@time}"
+          end
+
+          def failed_msg(candidates)
+            if candidates.length == 1
+              "job at #{candidates.first[:run_at]}"
+            else
+              "jobs at #{candidates.map { |c| c[:run_at] }}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/que/queue_up/queued_class.rb
+++ b/lib/rspec/que/queue_up/queued_class.rb
@@ -1,0 +1,31 @@
+module RSpec
+  module Que
+    module Matchers
+      class QueueUp
+        class QueuedClass
+          attr_reader :job_class
+          def initialize(job_class)
+            @job_class = job_class
+          end
+
+          def matches?(job)
+            job[:job_class] == job_class.to_s
+          end
+
+          def desc
+            "of class #{job_class}"
+          end
+
+          def failed_msg(candidates)
+            classes = candidates.map { |c| c[:job_class] }
+            if classes.length == 1
+              classes.first
+            else
+              "#{classes.length} jobs of class [#{classes.join(', ')}]"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/que/queue_up/queued_priority.rb
+++ b/lib/rspec/que/queue_up/queued_priority.rb
@@ -1,0 +1,29 @@
+module RSpec
+  module Que
+    module Matchers
+      class QueueUp
+        class QueuedPriority
+          def initialize(priority)
+            @priority = priority
+          end
+
+          def matches?(job)
+            job[:priority] == @priority
+          end
+
+          def desc
+            "of priority #{@priority}"
+          end
+
+          def failed_msg(candidates)
+            if candidates.length == 1
+              "job of priority #{candidates.first[:priority]}"
+            else
+              "jobs of priority #{candidates.map { |c| c[:priority] }}"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/rspec/que/queue_up/queued_something.rb
+++ b/lib/rspec/que/queue_up/queued_something.rb
@@ -1,0 +1,22 @@
+module RSpec
+  module Que
+    module Matchers
+      class QueueUp
+        class QueuedSomething
+          def matches?(_job)
+            true
+          end
+
+          def desc
+            "a job"
+          end
+
+          def failed_msg(_last_found)
+            "nothing"
+          end
+        end
+      end
+    end
+  end
+end
+

--- a/spec/rspec/que/queue_up_spec.rb
+++ b/spec/rspec/que/queue_up_spec.rb
@@ -46,7 +46,7 @@ RSpec.describe RSpec::Que::Matchers::QueueUp do
       let(:proc) { -> { enqueued_jobs << job_a << job_b } }
 
       context "and one is of acceptable type" do
-        it { is_expected.to be(true) }
+        it { is_expected.to be(false) }
       end
 
       context "and we were expecting none of the first type" do
@@ -189,7 +189,6 @@ RSpec.describe RSpec::Que::Matchers::QueueUp do
     let(:proc) do
       lambda do
         enqueued_jobs << { job_class: "AJob", args: ['kyubey'], priority: 1 }
-        enqueued_jobs << { job_class: "BJob", args: ['fav-pon'], priority: 30 }
         enqueued_jobs << { job_class: "AJob", args: ['beetle'], priority: 30 }
       end
     end
@@ -198,7 +197,7 @@ RSpec.describe RSpec::Que::Matchers::QueueUp do
       it "should match jobs of the specified priority" do
         expect(instance.of_priority(30).matches?(proc)).to eq(true)
         expect(instance.failure_message_when_negated).to eq(
-          %(expected not to enqueue a job of priority 30, got 2 enqueued: BJob[fav-pon], AJob[beetle])
+          %(expected not to enqueue a job of priority 30, got 1 enqueued: AJob[beetle])
         )
       end
     end
@@ -382,7 +381,7 @@ RSpec.describe RSpec::Que::Matchers::QueueUp do
           specify do
             subject
             expect(instance.failure_message).
-              to eq("expected to enqueue a job of class AJob with args [\"arg1\"] exactly 1 times, but found 2 jobs")
+              to eq("expected to enqueue a job of class AJob with args [\"arg1\"], but found 2 jobs")
           end
         end
 


### PR DESCRIPTION
This commit adds support for `#exactly`, `#at_most` and `#at_least`, as well
as the convenience methods `#once` and `#twice`. These will extend the
matcher to check that the job was enqueued the specified number of
times.

The second commit is up for debate:
It introduces a breaking change which means we no longer return true if you enqueue multiple matching jobs but don't specify a number.

e.g.
with a job list
```ruby
[ { job_class: "AJob" }, { job_class: "AJob" }]
```
the expectation
```ruby
expect { ... }.to queue_up(AJob)
```
would previously be true.
After this change, it would be false unless you modified the expectation:
```ruby
expect { ... }.to queue_up(AJob).at_least(2).times
# or
expect { ... }.to queue_up(AJob).exactly(2).times
```